### PR TITLE
クリックイベントを親要素に設定する変更を実装

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -5,10 +5,7 @@ export const Board = (props) => {
   function renderSquare(i) {
     return (
       <Square
-        value={props.squares[i]}
-        onClick={() => {
-          props.onClick(i);
-        }}
+        mark={props.squares[i]}
         no={i}
       />
     );

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -9,6 +9,7 @@ export const Board = (props) => {
         onClick={() => {
           props.onClick(i);
         }}
+        no={i}
       />
     );
   }

--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -1,7 +1,6 @@
-import { useState } from "react";
-import { Board } from "./Board";
-import { calcWinner } from "./utils";
-
+import { useState } from 'react';
+import { Board } from './Board';
+import { calcWinner } from './utils';
 
 export const Game = () => {
   const [history, setHistory] = useState([{ squares: Array(9).fill(null) }]);
@@ -26,16 +25,27 @@ export const Game = () => {
     setXIsNext(step % 2 === 0);
   }
 
-  function handleClick(i) {
-    const newSquares = [...current.squares];
-    if (newSquares[i] || winner) {
+  function handleClick(e) {
+    e.preventDefault();
+    // マス以外のdiv.game-boardの範囲をクリックした場合
+    if (e.target.value === undefined) {
+      e.stopPropagation();
       return;
     }
-    newSquares[i] = xIsNext ? 'X' : 'O';
+    const newSquares = [...current.squares];
+    // 既にマスが埋まっているか勝者が決まっている
+    if (newSquares[e.target.value] || winner) {
+      e.stopPropagation();
+      return;
+    }
+
+    newSquares[e.target.value] = xIsNext ? 'X' : 'O';
     const pastHistory = history.slice(0, stepNumber + 1);
     setHistory([...pastHistory, { squares: newSquares }]);
     setXIsNext((prev) => !prev);
     setStepNumber((prev) => prev + 1);
+
+    e.stopPropagation();
   }
 
   let status;
@@ -47,8 +57,8 @@ export const Game = () => {
 
   return (
     <div className='game'>
-      <div className='game-board'>
-        <Board squares={current.squares} onClick={(i) => handleClick(i)} />
+      <div className='game-board' onClick={(e) => handleClick(e)}>
+        <Board squares={current.squares} />
       </div>
       <div className='game-info'>
         <div>{status}</div>

--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -11,11 +11,11 @@ export const Game = () => {
 
   const winner = calcWinner(current.squares);
 
-  const moves = history.map((_, move) => {
-    const desc = move ? `Go to move #${move}` : 'Go to game start';
+  const steps = history.map((_, step) => {
+    const desc = step ? `Go to move #${step}` : 'Go to game start';
     return (
-      <li key={move}>
-        <button onClick={() => jumpTo(move)}>{desc}</button>
+      <li key={step}>
+        <button onClick={() => jumpTo(step)}>{desc}</button>
       </li>
     );
   });
@@ -62,7 +62,7 @@ export const Game = () => {
       </div>
       <div className='game-info'>
         <div>{status}</div>
-        <ol>{moves}</ol>
+        <ol>{steps}</ol>
       </div>
     </div>
   );

--- a/src/Square.jsx
+++ b/src/Square.jsx
@@ -1,6 +1,6 @@
 export const Square = (props) => {
   return (
-    <button className='square' onClick={props.onClick}>
+    <button className='square' onClick={props.onClick} value={props.no}>
       {props.value}
     </button>
   );

--- a/src/Square.jsx
+++ b/src/Square.jsx
@@ -1,7 +1,7 @@
 export const Square = (props) => {
   return (
-    <button className='square' onClick={props.onClick} value={props.no}>
-      {props.value}
+    <button className='square' value={props.no}>
+      {props.mark}
     </button>
   );
 };


### PR DESCRIPTION
close #5

# やったこと

クリックイベントをSquareコンポーネントに個別 -> 親要素のdiv.game-boardに当てる変更
これによってGameコンポーネントからpropsでイベントハンドラをSquareコンポーネントまで引き回す必要がなくなった