### PR TITLE
イベントリスナーを適切な要素に設定する修正の実装

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -20,5 +20,5 @@ export const Board = (props) => {
     );
   }
 
-  return <div>{grid}</div>;
+  return <div onClick={(e) => props.onClick(e)}>{grid}</div>;
 };

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -6,9 +6,9 @@ export const Board = (props) => {
     return <Square mark={props.squares[i]} no={i} />;
   }
 
-  let grid = [];
+  const grid = [];
   for (let y = 0; y < 3; y++) {
-    let row = [];
+    const row = [];
     for (let x = 0; x < 3; x++) {
       const serialNo = 3 * y + x;
       row.push(<Fragment key={serialNo}>{renderSquare(serialNo)}</Fragment>);

--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -41,11 +41,6 @@ export const Game = () => {
 
   function handleClick(e) {
     e.preventDefault();
-    // マス以外のdiv.game-boardの範囲をクリックした場合は何もしない
-    if (e.target.value === undefined) {
-      e.stopPropagation();
-      return;
-    }
     const newSquares = [...current.squares];
     const pos = Number(e.target.value);
     // 既にマスが埋まっているか勝者が決まっている場合は何もしない
@@ -66,8 +61,8 @@ export const Game = () => {
 
   return (
     <div className='game'>
-      <div className='game-board' onClick={(e) => handleClick(e)}>
-        <Board squares={current.squares} />
+      <div className='game-board'>
+        <Board squares={current.squares} onClick={(e) => handleClick(e)}/>
       </div>
       <div className='game-info'>
         <div>{status}</div>


### PR DESCRIPTION
close #12 

# やったこと

- マスをクリックした時のイベントリスナーをGameコンポーネントの `div.game-board` からBoardコンポーネントに移行
  - これによってBoardコンポーネントとその配下のSquareコンポーネントにのみ反応するイベントを設定できた
- `e.target.value` で `undefined` を取る可能性がなくなったのでその部分の処理を削除

# 修正

- Boardコンポーネントの配列の変数宣言をletからconstに修正 24eb516