### PR TITLE
マス目をクリックしたときに意図しない値が返ってくる問題の修正

### DIFF
--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -44,9 +44,8 @@ export const Game = () => {
     e.preventDefault();
     const current = history[stepNumber];
     const squares = [...current.squares];
-    const pos = Number(e.target.value);
-    // 既にマスが埋まっているか勝者が決まっている場合は何もしない
-    if (squares[pos] || calcWinner(squares)) {
+    const pos = Number(e.target.dataset.num);
+    if (Number.isNaN(pos) || squares[pos] || calcWinner(squares)) {
       e.stopPropagation();
       return;
     }

--- a/src/Square.jsx
+++ b/src/Square.jsx
@@ -2,7 +2,7 @@ export const Square = (props) => {
   return (
     <button
       className={props.isWin ? 'square win-square' : 'square'}
-      value={props.num}
+      data-num={props.num}
     >
       {props.mark}
     </button>


### PR DESCRIPTION
close #20

# やったこと

- イベント伝播によって上位の要素が `event.target` になることによって `undefined` が値として返ってきてしまう問題
- イベントリスナー関数を修正して意図しない値の場合は何もしないように修正
