### PR TITLE
イベントリスナーをマス目の要素に直接設定するように修正

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -7,7 +7,7 @@ export const Board = (props) => {
     return (
       <Square
         mark={props.squares[i]}
-        num={i}
+        onClick={() => props.onClick(i)}
         isWin={isWinSquare(props.squares, i)}
       />
     );
@@ -27,5 +27,5 @@ export const Board = (props) => {
     );
   }
 
-  return <div onClick={(e) => props.onClick(e)}>{grid}</div>;
+  return <div>{grid}</div>;
 };

--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -40,13 +40,11 @@ export const Game = () => {
     setXIsNext(step % 2 === 0);
   }
 
-  function handleClick(e) {
-    e.preventDefault();
+  function handleClick(i) {
     const current = history[stepNumber];
     const squares = [...current.squares];
-    const pos = Number(e.target.dataset.num);
-    if (Number.isNaN(pos) || squares[pos] || calcWinner(squares)) {
-      e.stopPropagation();
+    const pos = Number(i);
+    if (squares[pos] || calcWinner(squares)) {
       return;
     }
     // 現在の着手位置まで履歴を切り詰めてから新しい履歴を追加する
@@ -56,8 +54,6 @@ export const Game = () => {
     setHistory([...prevHistory, newHistory]);
     setXIsNext((prev) => !prev);
     setStepNumber((prev) => prev + 1);
-
-    e.stopPropagation();
   }
 
   function toggle() {
@@ -67,7 +63,7 @@ export const Game = () => {
   return (
     <div className='game'>
       <div className='game-board'>
-        <Board squares={current.squares} onClick={(e) => handleClick(e)} />
+        <Board squares={current.squares} onClick={(i) => handleClick(i)} />
       </div>
       <div className='game-info'>
         <div>{status}</div>

--- a/src/Square.jsx
+++ b/src/Square.jsx
@@ -2,7 +2,7 @@ export const Square = (props) => {
   return (
     <button
       className={props.isWin ? 'square win-square' : 'square'}
-      data-num={props.num}
+      onClick={props.onClick}
     >
       {props.mark}
     </button>


### PR DESCRIPTION
close #22

# やったこと

- Boardコンポーネントに設定していたリスナーをpropでSqurareコンポーネントに渡すようにした
- Squareの連番管理はBoardで行う
  - ↑リスナーと連番を分離できるのは色々便利かもしれない

# その他

- イベントオブジェクトを渡して ` e.preventDefault()`はしない（なのでイベントオブジェクト自体を渡さない）
  - ↑今回は必要ないと判断したのでイベントを引数に取る部分は削除した
- `<button>`タグに`type='button'`を設定もしていない
  - ↑デフォルトだと`submit`だがフォームの中にないボタンなら設定しなくても問題ないと判断